### PR TITLE
Set serial to 1738800000

### DIFF
--- a/crc.dev.zone
+++ b/crc.dev.zone
@@ -2,7 +2,7 @@ $ORIGIN dev.
 $TTL 5m
 
 crc     IN      SOA     ns1.osci.io. hostmaster.osci.io. (
-                        2025020102   ; serial
+                        1739404800   ; serial
                         4h           ; refresh
                         15m          ; retry
                         8h           ; expire


### PR DESCRIPTION
This matches the currently deployed serial, and will hopefully fix CI on
the main branch:
```
Zone 'crc.dev' new serial: 2025020102
Zone 'crc.dev' current serial: 1738800000
Zone 'crc.dev' serial does not match DNS
```